### PR TITLE
Deprecate signal get/clone methods

### DIFF
--- a/samples/test07_pendulum_with_pi.cpp
+++ b/samples/test07_pendulum_with_pi.cpp
@@ -33,6 +33,10 @@ protected:
 public:
     Pendulum() : pooya::Submodel("pendulum") {}
 
+    pooya::ScalarSignalId _m{nullptr};
+    pooya::ScalarSignalId _g{nullptr};
+    pooya::ScalarSignalId _l{nullptr};
+
     bool init(pooya::Parent& parent, pooya::BusId ibus, pooya::BusId obus) override
     {
         pooya_trace0;
@@ -41,29 +45,29 @@ public:
             return false;
 
         // create pooya signals
-        auto dphi = scalar_signal("dphi");
+        auto dphi = create_scalar_signal("dphi");
 
         // choose random names for these internal signals
-        auto s10 = scalar_signal();
-        auto s20 = scalar_signal();
-        auto s30 = scalar_signal();
-        auto s40 = scalar_signal();
+        auto s10 = create_scalar_signal();
+        auto s20 = create_scalar_signal();
+        auto s30 = create_scalar_signal();
+        auto s40 = create_scalar_signal();
 
         auto& model_ = model_ref();
-        auto m = model_.scalar_signal("m");
-        auto g = model_.scalar_signal("g");
-        auto l = model_.scalar_signal("l");
+        _m = model_.create_scalar_signal("m");
+        _g = model_.create_scalar_signal("g");
+        _l = model_.create_scalar_signal("l");
 
         auto tau = scalar_input_at(0);
         auto phi = scalar_output_at(0);
 
         // setup the submodel
-        add_block(_muldiv1, {tau, m, l, l},  s10);
+        add_block(_muldiv1, {tau, _m, _l, _l},  s10);
         add_block(_sub, {s10, s20}, s30);
         add_block(_integ1, s30, dphi);
         add_block(_integ2, dphi, phi);
         add_block(_sin, phi, s40);
-        add_block(_muldiv2, {s40, g, l}, s20);
+        add_block(_muldiv2, {s40, _g, _l}, s20);
 
         return true;
     }
@@ -93,9 +97,9 @@ public:
             return false;
 
         // choose random names for these internal signals
-        auto s10 = scalar_signal();
-        auto s20 = scalar_signal();
-        auto s30 = scalar_signal();
+        auto s10 = create_scalar_signal();
+        auto s20 = create_scalar_signal();
+        auto s30 = create_scalar_signal();
 
         auto x = scalar_input_at(0);
         auto y = scalar_output_at(0);
@@ -115,10 +119,12 @@ class PendulumWithPI : public pooya::Submodel
 protected:
     pooya::Subtract _sub{"Sub"};
     PI _pi{40.0, 20.0};
-    Pendulum _pend;
 
 public:
     PendulumWithPI() : pooya::Submodel("pendulum_with_PI") {}
+
+    Pendulum _pend;
+    pooya::ScalarSignalId _des_phi{nullptr};
 
     bool init(pooya::Parent& parent, pooya::BusId, pooya::BusId) override
     {
@@ -128,14 +134,14 @@ public:
             return false;
 
         // signals
-        auto phi = scalar_signal("phi");
-        auto tau = scalar_signal("tau");
-        auto err = scalar_signal("err");
+        auto phi = create_scalar_signal("phi");
+        auto tau = create_scalar_signal("tau");
+        auto err = create_scalar_signal("err");
 
-        auto des_phi = model_ref().scalar_signal("des_phi");
+        _des_phi = create_scalar_signal("des_phi");
 
         // blocks
-        add_block(_sub, {des_phi, phi}, err);
+        add_block(_sub, {_des_phi, phi}, err);
         add_block(_pi, err, tau);
         add_block(_pend, tau, phi);
 
@@ -157,20 +163,15 @@ int main()
     // setup the model
     model.add_block(pendulum_with_pi);
 
-    auto m = model.scalar_signal("m");
-    auto l = model.scalar_signal("l");
-    auto g = model.scalar_signal("g");
-    auto des_phi = model.scalar_signal("des_phi");
-
     pooya::Rkf45 stepper;
     pooya::Simulator sim(model,
         [&](pooya::Model&, double /*t*/) -> void
         {
             pooya_trace0;
-            m->set(0.2);
-            l->set(0.1);
-            g->set(9.81);
-            des_phi->set(M_PI_4);
+            pendulum_with_pi._pend._m->set(0.2);
+            pendulum_with_pi._pend._l->set(0.1);
+            pendulum_with_pi._pend._g->set(9.81);
+            pendulum_with_pi._des_phi->set(M_PI_4);
         },
         &stepper); // try Rk4 with h = 0.01 to see the difference
 

--- a/samples/test09_mass_spring_damper.cpp
+++ b/samples/test09_mass_spring_damper.cpp
@@ -47,9 +47,9 @@ public:
 
         _s_tau = scalar_input_at(0);
 
-        _s_x = parent.scalar_signal("x");
-        _s_xd = parent.scalar_signal("xd");
-        _s_xdd = parent.scalar_signal("xdd");
+        _s_x = parent.create_scalar_signal("x");
+        _s_xd = parent.create_scalar_signal("xd");
+        _s_xdd = parent.create_scalar_signal("xdd");
 
         auto& model_ = model_ref();
         model_.register_state_variable(_s_x, _s_xd);
@@ -95,7 +95,7 @@ int main()
     MassSpringDamper msd("msd", 1, 1, 0.1, 0.1, -0.2);
 
     // create pooya signals
-    auto tau = model.scalar_signal("tau");
+    auto tau = model.create_scalar_signal("tau");
 
     // setup the model
     model.add_block(msd, tau);

--- a/samples/test10_memory_with_bus.cpp
+++ b/samples/test10_memory_with_bus.cpp
@@ -52,7 +52,7 @@ int main()
 
     // create buses (signals)
 
-    auto x = model.bus("x", bus_spec); // assign bus wires implicitely
+    auto x = model.create_bus("x", bus_spec); // assign bus wires implicitely
     /*
     // alternative 1
     auto x = model.bus("x", bus_spec, { // assign bus wires explicitely without
@@ -72,7 +72,7 @@ int main()
     });
     */
 
-    auto y = model.bus("y", bus_spec);
+    auto y = model.create_bus("y", bus_spec);
 
     // setup the model
     model.add_block(bus_memory, x, y);

--- a/src/core/block_base.cpp
+++ b/src/core/block_base.cpp
@@ -274,12 +274,6 @@ bool Parent::traverse(TraverseCallback cb, uint32_t level, decltype(level) max_l
     return true;
 }
 
-SignalId Parent::get_generic_signal(const std::string& given_name)
-{
-    pooya_trace("block: " + full_name());
-    return model_ref().lookup_signal(make_signal_name(given_name), true);
-}
-
 template<typename Iter>
 BusId Parent::create_bus(const std::string& given_name, const BusSpec& spec, Iter begin_, Iter end_)
 {
@@ -344,34 +338,6 @@ BusId Parent::create_bus(const std::string& given_name, const BusSpec& spec, con
     }
 
     return create_bus(given_name, spec, label_signals.begin(), label_signals.end());
-}
-
-SignalId Parent::clone_signal(const std::string& given_name, SignalId sig)
-{
-    pooya_trace("block: " + full_name());
-    pooya_verify_valid_signal(sig);
-    if (sig->is_scalar())
-    {
-        return create_scalar_signal(given_name);
-    }
-    else if (sig->is_array())
-    {
-        return create_array_signal(given_name, sig->as_array()->size());
-    }
-    else
-    {
-        pooya_verify_bus(sig);
-        BusId bus = sig->as_bus();
-        std::size_t n = bus->spec()._wires.size();
-        std::vector<LabelSignalId> sigs;
-        sigs.reserve(n);
-        for (std::size_t k = 0; k < n; k++)
-        {
-            const auto& ns = bus->at(k);
-            sigs.emplace_back(ns.first, clone_signal("", ns.second));
-        }
-        return create_bus(given_name, bus->spec(), sigs.begin(), sigs.end());
-    }
 }
 
 bool Parent::add_block(Block& component, const LabelSignals& iports, const LabelSignals& oports)

--- a/src/core/block_base.hpp
+++ b/src/core/block_base.hpp
@@ -270,75 +270,6 @@ public:
 #endif // defined(POOYA_USE_SMART_PTRS)
     }
 
-    // retrieve an existing signal
-    SignalId get_generic_signal(const std::string& given_name);
-    template<typename T, typename... Ts>
-    typename Types<T>::SignalId get_signal(const std::string& given_name, Ts... args)
-    {
-        pooya_trace("block: " + full_name() + ", given name: " + given_name);
-        SignalId sig = get_generic_signal(given_name);
-        if (!sig) {return typename Types<T>::SignalId();}
-        Types<T>::verify_signal_type(sig, args...);
-        return Types<T>::as_type(sig);
-    }
-
-    ScalarSignalId get_scalar_signal(const std::string& given_name)
-    {
-        pooya_trace("block: " + full_name() + ", given name: " + given_name);
-        return get_signal<double>(given_name);
-    }
-    IntSignalId get_int_signal(const std::string& given_name)
-    {
-        pooya_trace("block: " + full_name() + ", given name: " + given_name);
-        return get_signal<int>(given_name);
-    }
-    BoolSignalId get_bool_signal(const std::string& given_name)
-    {
-        pooya_trace("block: " + full_name() + ", given name: " + given_name);
-        return get_signal<bool>(given_name);
-    }
-    ArraySignalId get_array_signal(const std::string& given_name, std::size_t size)
-    {
-        pooya_trace("block: " + full_name() + ", given name: " + given_name);
-        return get_signal<Array>(given_name, size);
-    }
-    BusId get_bus(const std::string& given_name, const BusSpec& spec)
-    {
-        pooya_trace("block: " + full_name() + ", given name: " + given_name);
-        return get_signal<BusSpec>(given_name, spec);
-    }
-
-    // get if exists, create otherwise
-    template<typename T, typename... Ts>
-    typename Types<T>::SignalId signal(const std::string& given_name="", Ts... args)
-    {
-        pooya_trace("block: " + full_name() + ", given name: " + given_name);
-        auto sig = get_signal<T, Ts...>(given_name, args...);
-        return sig ? sig : create_signal<T, Ts...>(given_name, args...);
-    }
-
-    ScalarSignalId scalar_signal(const std::string& given_name="")
-    {
-        pooya_trace("block: " + full_name() + ", given name: " + given_name);
-        return signal<double>(given_name);
-    }
-    IntSignalId int_signal(const std::string& given_name="")
-    {
-        pooya_trace("block: " + full_name() + ", given name: " + given_name);
-        return signal<int>(given_name);
-    }
-    BoolSignalId bool_signal(const std::string& given_name="")
-    {
-        pooya_trace("block: " + full_name() + ", given name: " + given_name);
-        return signal<bool>(given_name);
-    }
-    BusId bus(const std::string& given_name, const BusSpec& spec)
-    {
-        pooya_trace("block: " + full_name() + ", given name: " + given_name);
-        auto sig = get_bus(given_name, spec);
-        return sig ? sig : create_bus(given_name, spec);
-    }
-
     // create with a unique name
     template<typename T, typename... Ts>
     typename Types<T>::SignalId create_signal(const std::string& given_name="", Ts... args);
@@ -364,34 +295,6 @@ public:
     {
         pooya_trace("block: " + full_name() + ", given name: " + given_name);
         return create_signal<Array, std::size_t>(given_name, size);
-    }
-
-    // clone (make a new copy)
-    SignalId clone_signal(const std::string& given_name, SignalId sig);
-    ScalarSignalId clone_signal(const std::string& given_name, ScalarSignalId sig)
-    {
-        pooya_trace("block: " + full_name());
-        return clone_signal(given_name, SignalId(sig))->as_scalar();
-    }
-    IntSignalId clone_signal(const std::string& given_name, IntSignalId sig)
-    {
-        pooya_trace("block: " + full_name());
-        return clone_signal(given_name, SignalId(sig))->as_int();
-    }
-    BoolSignalId clone_signal(const std::string& given_name, BoolSignalId sig)
-    {
-        pooya_trace("block: " + full_name());
-        return clone_signal(given_name, SignalId(sig))->as_bool();
-    }
-    ArraySignalId clone_signal(const std::string& given_name, ArraySignalId sig)
-    {
-        pooya_trace("block: " + full_name());
-        return clone_signal(given_name, SignalId(sig))->as_array();
-    }
-    BusId clone_bus(const std::string& given_name, BusId sig)
-    {
-        pooya_trace("block: " + full_name());
-        return clone_signal(given_name, SignalId(sig))->as_bus();
     }
 
     std::string make_signal_name(const std::string& given_name, bool make_new=false);


### PR DESCRIPTION

The signal get/clone methods are practically useless so better to deprecate them.
