### PR TITLE
Delete default assignment operator of signals

### DIFF
--- a/samples/test07_pendulum_with_pi.cpp
+++ b/samples/test07_pendulum_with_pi.cpp
@@ -54,12 +54,10 @@ public:
 
         // create pooya signals
         pooya::ScalarSignal dphi("dphi");
-
-        // choose random names for these internal signals
-        pooya::ScalarSignal s10("");
-        pooya::ScalarSignal s20("");
-        pooya::ScalarSignal s30("");
-        pooya::ScalarSignal s40("");
+        pooya::ScalarSignal s10;
+        pooya::ScalarSignal s20;
+        pooya::ScalarSignal s30;
+        pooya::ScalarSignal s40;
 
         auto tau = scalar_input_at(0);
         auto phi = scalar_output_at(0);
@@ -99,10 +97,9 @@ public:
         if (!pooya::Submodel::init(parent, ibus, obus))
             return false;
 
-        // choose random names for these internal signals
-        pooya::ScalarSignal s10("");
-        pooya::ScalarSignal s20("");
-        pooya::ScalarSignal s30("");
+        pooya::ScalarSignal s10;
+        pooya::ScalarSignal s20;
+        pooya::ScalarSignal s30;
 
         auto x = scalar_input_at(0);
         auto y = scalar_output_at(0);

--- a/samples/test08_pendulum_with_pid.cpp
+++ b/samples/test08_pendulum_with_pid.cpp
@@ -99,7 +99,6 @@ public:
         if (!pooya::Submodel::init(parent, ibus, obus))
             return false;
 
-        // choose random names for these internal signals
         pooya::ScalarSignal s10;
         pooya::ScalarSignal s20;
         pooya::ScalarSignal s30;

--- a/samples/test09_mass_spring_damper.cpp
+++ b/samples/test09_mass_spring_damper.cpp
@@ -47,7 +47,7 @@ public:
         if (!pooya::Block::init(parent, ibus))
             return false;
 
-        _s_tau = scalar_input_at(0);
+        _s_tau.reset(scalar_input_at(0));
 
         _s_x.set_deriv_signal(_s_xd);
         _s_xd.set_deriv_signal(_s_xdd);

--- a/samples/tut01_mass_spring_damper.cpp
+++ b/samples/tut01_mass_spring_damper.cpp
@@ -42,13 +42,13 @@ int main()
     pooya::Gain       gain_k_m("k_m", k / m);
 
     // create pooya signals
-    pooya::ScalarSignalId s_F     = pooya::ScalarSignalInfo::create_new("F");
-    pooya::ScalarSignalId s_F_m   = pooya::ScalarSignalInfo::create_new("F_m");
-    pooya::ScalarSignalId s_xdd   = pooya::ScalarSignalInfo::create_new("xdd");
-    pooya::ScalarSignalId s_xd    = pooya::ScalarSignalInfo::create_new("xd");
-    pooya::ScalarSignalId s_x     = pooya::ScalarSignalInfo::create_new("x");
-    pooya::ScalarSignalId s_kx_m  = pooya::ScalarSignalInfo::create_new("kx_m");
-    pooya::ScalarSignalId s_cxd_m = pooya::ScalarSignalInfo::create_new("cxd_m");
+    pooya::ScalarSignal s_F("F");
+    pooya::ScalarSignal s_F_m("F_m");
+    pooya::ScalarSignal s_xdd("xdd");
+    pooya::ScalarSignal s_xd("xd");
+    pooya::ScalarSignal s_x("x");
+    pooya::ScalarSignal s_kx_m("kx_m");
+    pooya::ScalarSignal s_cxd_m("cxd_m");
 
     // set up the model
     model.add_block(src_F, {}, s_F);
@@ -62,6 +62,7 @@ int main()
     // set up the simulator
     pooya::Rk4 solver;
     pooya::Simulator sim(model, nullptr, &solver);
+
     pooya::History history(model);
     history.track(s_x);
     history.track(s_xd);

--- a/src/signal/array_signal.hpp
+++ b/src/signal/array_signal.hpp
@@ -38,12 +38,12 @@ protected:
     Array _array_value;
 
 public:
-    ArraySignalInfo(Protected, const std::string& full_name="", std::size_t size=1)
+    ArraySignalInfo(Protected, std::size_t size, const std::string& full_name)
         : FloatSignalInfo(full_name, ArrayType, size), _array_value(size) {}
 
-    static ArraySignalId create_new(const std::string& full_name, std::size_t size)
+    static ArraySignalId create_new(std::size_t size, const std::string& full_name="")
     {
-        return std::make_shared<ArraySignalInfo>(Protected(), full_name, size);
+        return std::make_shared<ArraySignalInfo>(Protected(), size, full_name);
     } 
 
     const Array& get() const
@@ -83,10 +83,19 @@ class ArraySignal : public FloatSignal<ArraySignal, Array>
     using Base = FloatSignal<ArraySignal, Array>;
 
 public:
-    explicit ArraySignal(const std::string& full_name, std::size_t size) : Base(ArraySignalInfo::create_new(full_name, size)) {}
+    explicit ArraySignal(std::size_t size=1, const std::string& full_name="") : Base(ArraySignalInfo::create_new(size, full_name)) {}
     ArraySignal(const ArraySignalId& sid) : Base(sid) {}
 
+    ArraySignal& operator=(const ArraySignal&) = delete;
+
+    void reset(std::size_t size, const std::string& full_name="")
+    {
+        _sid = ArraySignalInfo::create_new(size, full_name);
+    }
+
     using Signal<ArraySignal, Array>::operator=;
+    using Signal<ArraySignal, Array>::reset;
+
     double operator[](std::size_t index) const {return _sid->get()[index];}
 };
 

--- a/src/signal/bool_signal.hpp
+++ b/src/signal/bool_signal.hpp
@@ -38,7 +38,7 @@ public:
     BoolSignalInfo(Protected, const std::string& full_name)
         : ValueSignalInfo(full_name, BoolType) {}
 
-    static BoolSignalId create_new(const std::string& full_name)
+    static BoolSignalId create_new(const std::string& full_name="")
     {
         return std::make_shared<BoolSignalInfo>(Protected(), full_name);
     } 
@@ -81,7 +81,15 @@ public:
     explicit BoolSignal(const std::string& full_name="") : Base(BoolSignalInfo::create_new(full_name)) {}
     BoolSignal(const BoolSignalId& sid) : Base(sid) {}
 
+    BoolSignal& operator=(const BoolSignal&) = delete;
+
+    void reset(const std::string& full_name="")
+    {
+        _sid = BoolSignalInfo::create_new(full_name);
+    }
+
     using Signal<BoolSignal, bool>::operator=;
+    using Signal<BoolSignal, bool>::reset;
 };
 
 }

--- a/src/signal/bus.hpp
+++ b/src/signal/bus.hpp
@@ -178,7 +178,7 @@ public:
                 if (wit->_bus)
                     {ls.second = BusInfo::create_new(name, (*wit->_bus).get());}
                 else if (wit->_array_size > 0)
-                    {ls.second = ArraySignalInfo::create_new(name, wit->_array_size);}
+                    {ls.second = ArraySignalInfo::create_new(wit->_array_size, name);}
                 else if (wit->single_value_type() == BusSpec::SingleValueType::Scalar)
                     {ls.second = ScalarSignalInfo::create_new(name);}
                 else if (wit->single_value_type() == BusSpec::SingleValueType::Int)
@@ -196,12 +196,14 @@ public:
 
     static BusId create_new(const std::string& full_name, const BusSpec& spec, const std::initializer_list<LabelSignalId>& l)
     {
+        pooya_trace("create_new: " + full_name);
         pooya_verify(l.size() <= spec._wires.size(), "Too many entries in the initializer list!");
         return create_new(full_name, spec, l.begin(), l.end());
     }
 
     static BusId create_new(const std::string& full_name, const BusSpec& spec, const std::initializer_list<SignalId>& l={})
     {
+        pooya_trace("create_new: " + full_name);
         pooya_verify(l.size() <= spec._wires.size(), "Too many entries in the initializer list!");
 
         LabelSignalIdList label_signals;

--- a/src/signal/float_signal.hpp
+++ b/src/signal/float_signal.hpp
@@ -67,6 +67,8 @@ class FloatSignal : public ValueSignal<Derived, T>
 public:
     explicit FloatSignal(const typename Types<T>::SignalId& sid) : ValueSignal<Derived, T>(sid) {}
 
+    FloatSignal& operator=(const FloatSignal&) = delete;
+
     void set_deriv_signal(FloatSignalId deriv_sig) {static_cast<Derived*>(this)->id()->set_deriv_signal(deriv_sig);}
 
     operator FloatSignalId() const {return std::static_pointer_cast<FloatSignalInfo>(static_cast<const Derived*>(this)->id()->shared_from_this());}

--- a/src/signal/int_signal.hpp
+++ b/src/signal/int_signal.hpp
@@ -40,7 +40,7 @@ public:
     IntSignalInfo(Protected, const std::string& full_name)
         : ValueSignalInfo(full_name, IntType) {}
 
-    static IntSignalId create_new(const std::string& full_name)
+    static IntSignalId create_new(const std::string& full_name="")
     {
         return std::make_shared<IntSignalInfo>(Protected(), full_name);
     } 
@@ -83,7 +83,15 @@ public:
     explicit IntSignal(const std::string& full_name="") : Base(IntSignalInfo::create_new(full_name)) {}
     IntSignal(const IntSignalId& sid) : Base(sid) {}
 
+    IntSignal& operator=(const IntSignal&) = delete;
+
+    void reset(const std::string& full_name="")
+    {
+        _sid = IntSignalInfo::create_new(full_name);
+    }
+
     using Signal<IntSignal, int>::operator=;
+    using Signal<IntSignal, int>::reset;
 };
 
 }

--- a/src/signal/scalar_signal.hpp
+++ b/src/signal/scalar_signal.hpp
@@ -37,7 +37,7 @@ public:
     ScalarSignalInfo(Protected, const std::string& full_name)
         : FloatSignalInfo(full_name, ScalarType) {}
 
-    static ScalarSignalId create_new(const std::string& full_name)
+    static ScalarSignalId create_new(const std::string& full_name="")
     {
         return std::make_shared<ScalarSignalInfo>(Protected(), full_name);
     } 
@@ -80,7 +80,15 @@ public:
     explicit ScalarSignal(const std::string& full_name="") : Base(ScalarSignalInfo::create_new(full_name)) {}
     ScalarSignal(const ScalarSignalId& sid) : Base(sid) {}
 
+    ScalarSignal& operator=(const ScalarSignal&) = delete;
+
+    void reset(const std::string& full_name="")
+    {
+        _sid = ScalarSignalInfo::create_new(full_name);
+    }
+
     using Signal<ScalarSignal, double>::operator=;
+    using Signal<ScalarSignal, double>::reset;
 };
 
 }

--- a/src/signal/signal.hpp
+++ b/src/signal/signal.hpp
@@ -88,12 +88,14 @@ protected:
     }
 
 public:
-    explicit Signal(const typename Types<T>::SignalId& sid) : _sid(sid)
+    explicit Signal(const typename Types<T>::SignalId& sid)
     {
-        fail_if_invalid_signal(sid);
+        reset(sid);
     }
 
-    void operator=(const typename Types<T>::SignalId& sid)
+    Signal<Derived, T>& operator=(const Signal<Derived, T>&) = delete;
+
+    void reset(const typename Types<T>::SignalId& sid)
     {
         fail_if_invalid_signal(sid);
         _sid = sid;

--- a/src/signal/trait.hpp
+++ b/src/signal/trait.hpp
@@ -18,7 +18,6 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 #include "src/helper/verify.hpp"
 #include "array.hpp"
 #include "signal_id.hpp"
-#include <memory>
 
 namespace pooya
 {
@@ -44,7 +43,7 @@ struct Types<Array>
     static void verify_signal_type(pooya::SignalId sig);
     static void verify_signal_type(pooya::SignalId sig, std::size_t size);
 #endif // defined(POOYA_DEBUG)
-    template<typename T> static SignalInfo& is_same_type(const T& sig) {return sig->is_array();}
+    template<typename T> static bool is_same_type(const T& sig) {return sig->is_array();}
     template<typename T> static SignalInfo& as_signal_info(const T& sig) {return sig->as_array();}
     template<typename T> static SignalId as_signal_id(const T& sig)
     {
@@ -66,7 +65,7 @@ struct Types<double>
 #if defined(POOYA_DEBUG)
     static void verify_signal_type(pooya::SignalId sig);
 #endif // defined(POOYA_DEBUG)
-    template<typename T> static SignalInfo& is_same_type(const T& sig) {return sig->is_scalar();}
+    template<typename T> static bool is_same_type(const T& sig) {return sig->is_scalar();}
     template<typename T> static SignalInfo& as_signal_info(const T& sig) {return sig->as_scalar();}
     template<typename T> static SignalId as_signal_id(const T& sig)
     {
@@ -88,7 +87,7 @@ struct Types<int>
 #if defined(POOYA_DEBUG)
     static void verify_signal_type(pooya::SignalId sig);
 #endif // defined(POOYA_DEBUG)
-    template<typename T> static SignalInfo& is_same_type(const T& sig) {return sig->is_int();}
+    template<typename T> static bool is_same_type(const T& sig) {return sig->is_int();}
     template<typename T> static SignalInfo& as_signal_info(const T& sig) {return sig->as_int();}
     template<typename T> static SignalId as_signal_id(const T& sig)
     {
@@ -110,7 +109,7 @@ struct Types<bool>
 #if defined(POOYA_DEBUG)
     static void verify_signal_type(pooya::SignalId sig);
 #endif // defined(POOYA_DEBUG)
-    template<typename T> static SignalInfo& is_same_type(const T& sig) {return sig->is_bool();}
+    template<typename T> static bool is_same_type(const T& sig) {return sig->is_bool();}
     template<typename T> static SignalInfo& as_signal_info(const T& sig) {return sig->as_bool();}
     template<typename T> static SignalId as_signal_id(const T& sig)
     {
@@ -127,7 +126,7 @@ struct Types<BusSpec>
 #if defined(POOYA_DEBUG)
     static void verify_signal_type(pooya::SignalId sig, const BusSpec& spec);
 #endif // defined(POOYA_DEBUG)
-    template<typename T> static SignalInfo& is_same_type(const T& sig) {return sig->is_bus();}
+    template<typename T> static bool is_same_type(const T& sig) {return sig->is_bus();}
     template<typename T> static SignalInfo& as_signal_info(const T& sig) {return sig->as_bus();}
     template<typename T> static SignalId as_signal_id(const T& sig)
     {

--- a/src/signal/value_signal.hpp
+++ b/src/signal/value_signal.hpp
@@ -62,6 +62,8 @@ class ValueSignal : public Signal<Derived, T>
 public:
     explicit ValueSignal(const typename Types<T>::SignalId& sid) : Signal<Derived, T>(sid) {}
 
+    ValueSignal& operator=(const ValueSignal&) = delete;
+
     operator ValueSignalId() const {return std::static_pointer_cast<ValueSignalInfo>(static_cast<const Derived*>(this)->id()->shared_from_this());}
 };
 

--- a/tests/test_delay.cpp
+++ b/tests/test_delay.cpp
@@ -101,9 +101,9 @@ TEST_F(TestDelay, ArrayDelay)
     pooya::Submodel model("");
     pooya::DelayA delay("delay");
     pooya::ScalarSignal s_time_delay("time_delay");
-    pooya::ArraySignal s_initial("initial", N);
-    pooya::ArraySignal s_x("x", N);
-    pooya::ArraySignal s_y("y", N);
+    pooya::ArraySignal s_initial(N, "initial");
+    pooya::ArraySignal s_x(N, "x");
+    pooya::ArraySignal s_y(N, "y");
     model.add_block(delay, {
         {"delay", s_time_delay},
         {"in", s_x},

--- a/tests/test_gain.cpp
+++ b/tests/test_gain.cpp
@@ -66,8 +66,8 @@ TEST_F(TestGain, ArrayGain)
     // model setup
     pooya::Submodel model("");
     pooya::GainA gain("gain", -5.89);
-    pooya::ArraySignal s_x("x", N);
-    pooya::ArraySignal s_y("y", N);
+    pooya::ArraySignal s_x(N, "x");
+    pooya::ArraySignal s_y(N, "y");
     model.add_block(gain, s_x, s_y);
 
     // simulator setup

--- a/tests/test_memory.cpp
+++ b/tests/test_memory.cpp
@@ -40,15 +40,15 @@ TEST_F(TestMemory, ScalarMemory)
     // model setup
     pooya::Submodel model("");
     pooya::Memory memory("memory", x0);
-    auto s_x = pooya::ScalarSignalInfo::create_new("x");
-    auto s_y = pooya::ScalarSignalInfo::create_new("y");
+    pooya::ScalarSignal s_x("x");
+    pooya::ScalarSignal s_y("y");
     model.add_block(memory, s_x, s_y);
 
     // simulator setup
     pooya::Simulator sim(model,
         [&](pooya::Block&, double /*t*/) -> void
         {
-            s_x->set(x);
+            s_x = x;
         });
 
     // do one step
@@ -68,24 +68,23 @@ TEST_F(TestMemory, ArrayMemory)
     // model setup
     pooya::Submodel model("");
     pooya::MemoryA memory("memory", x0);
-    auto s_x = pooya::ArraySignalInfo::create_new("x", N);
-    auto s_y = pooya::ArraySignalInfo::create_new("y", N);
+    pooya::ArraySignal s_x(N, "x");
+    pooya::ArraySignal s_y(N, "y");
     model.add_block(memory, s_x, s_y);
 
     // simulator setup
     pooya::Simulator sim(model,
         [&](pooya::Block&, double /*t*/) -> void
         {
-            s_x->set(x);
+            s_x = x;
         });
 
     // do one step
     sim.init(0.0);
 
     // verify the results
-    auto y = s_y->get();
     for (std::size_t k=0; k < N; k++)
     {
-        EXPECT_EQ(y[k], x0[k]);
+        EXPECT_EQ(s_y[k], x0[k]);
     }
 }

--- a/todo.md
+++ b/todo.md
@@ -19,16 +19,16 @@
 * Create FloatSignalInfo
 * pass std::string as const ref
 * use gtest and cc_test
+* Deprecate Model
 
+- Remove Block::_parent
 - Unify given_name and full_name of signals
 - Define pooya_assert_* and pooya_verify_* where pooya_assert_* macros are debug-only and a preprocessor directive is used to exclude pooya_verify_* macros from the release build
 - Use static_assert() in pooya_assert_* macros
 - Deprecate BusSpec
-- Deprecate Model
 - Create an abstraction layer between pooya and Eigen
 - Reduce the usage of POOYA_USE_SMART_PTRS through defining proper macros or helper classes
 - Call pre_step and post_step for minor steps too
-- Make model mandatory
 - enclose the methods that only contain pooya_verify macros within #if...#endif blocks
 - Use DOT to generate a graph presentation of the model
 - Doxygen
@@ -43,3 +43,4 @@
 <!-- - light weight Signal wrapper so it supports operator[] -->
 <!-- - Make _assigned a debug-only flag (No. It is essential.) -->
 <!-- - support auto state variables (not necessary, use pooya::Integrator instead) -->
+<!-- - Make model mandatory -->


### PR DESCRIPTION
This PR restricts the assignment operator of value signals to value assignment. The new `reset` method must be used to replace the underlying signal ID.