### PR TITLE
Add block name to constructors

### DIFF
--- a/samples/delay_block.cpp
+++ b/samples/delay_block.cpp
@@ -35,9 +35,9 @@ protected:
                               pooya_trace0;
                               return std::sin(M_PI * t / 5);
                           }};
-    pooya::Const _const1{this, 2.7435};
-    pooya::Const _const2{this, 0.0};
-    pooya::Delay _delay{this, 10.0};
+    pooya::Const _const1{this, "", 2.7435};
+    pooya::Const _const2{this, "", 0.0};
+    pooya::Delay _delay{this, "", 10.0};
 
 public:
     pooya::ScalarSignal _s_x;

--- a/samples/test04_mass_spring.cpp
+++ b/samples/test04_mass_spring.cpp
@@ -31,22 +31,17 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 class MyModel : public pooya::Submodel
 {
 protected:
-    pooya::Integrator _integ1{this, 0.1};
-    pooya::Integrator _integ2{this};
-    pooya::Gain _gain{this, -1.0 / 1.0};
+    pooya::Integrator _integ1{this, "xd", 0.1};
+    pooya::Integrator _integ2{this, "x"};
+    pooya::Gain _gain{this, "-k\\m", -1.0 / 1.0};
 
 public:
     pooya::ScalarSignal _x{"x"};
     pooya::ScalarSignal _xd{"xd"};
     pooya::ScalarSignal _xdd{"xdd"};
 
-    MyModel()
+    MyModel(std::string_view name) : pooya::Submodel(nullptr, name)
     {
-        rename("MyModel");
-        _integ1.rename("xd");
-        _integ2.rename("x");
-        _gain.rename("-k\\m");
-
         _integ1.connect(_xdd, _xd);
         _integ2.connect(_xd, _x);
         _gain.connect(_x, _xdd);
@@ -61,7 +56,7 @@ int main()
     auto start  = std::chrono::high_resolution_clock::now();
 
     // create pooya blocks
-    MyModel model;
+    MyModel model("MyModel");
 
     pooya::Rk4 stepper;
     pooya::Simulator sim(model, nullptr, &stepper);

--- a/samples/test05_pendulum.cpp
+++ b/samples/test05_pendulum.cpp
@@ -32,11 +32,11 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 class Pendulum : public pooya::Submodel
 {
 protected:
-    pooya::Integrator _integ1{this};
-    pooya::Integrator _integ2{this, M_PI_4};
+    pooya::Integrator _integ1{this, "dphi"};
+    pooya::Integrator _integ2{this, "phi", M_PI_4};
     // pooya::SISOFunction _sin(this, [](double /*t*/, double x) -> double { return std::sin(x); });
-    pooya::Sin _sin{this};
-    pooya::MulDiv _muldiv{this, "**/", -1};
+    pooya::Sin _sin{this, "sin(phi)"};
+    pooya::MulDiv _muldiv{this, "-g\\l", "**/", -1};
 
 public:
     pooya::ScalarSignal _phi{"phi"};
@@ -48,11 +48,6 @@ public:
     Pendulum()
     {
         pooya_trace0;
-
-        _integ1.rename("dphi");
-        _integ2.rename("phi");
-        _sin.rename("sin(phi)");
-        _muldiv.rename("-g\\l");
 
         pooya::ScalarSignal s10;
 

--- a/samples/test06_pendulum_with_torque.cpp
+++ b/samples/test06_pendulum_with_torque.cpp
@@ -35,17 +35,17 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 class Pendulum : public pooya::Submodel
 {
 protected:
-    pooya::Integrator _integ1{this, M_PI_4};
-    pooya::Integrator _integ2{this};
-    // pooya::SISOFunction _sin(this, [](double /*t*/, double x) -> double { return std::sin(x); });
-    // pooya::SOFunction _sin(this, [](double /*t*/, const pooya::Bus& ibus) -> double
-    //                        { return std::sin(ibus.scalar_at(0)->get()); });
-    // pooya::Function _sin(this, [](double /*t*/, const pooya::Bus& ibus, const pooya::Bus& obus) -> void
-    //                      { obus.scalar_at(0)->set(std::sin(ibus.scalar_at(0)->get())); });
-    pooya::Sin _sin{this};
-    pooya::MulDiv _muldiv1{this, "**/"};
-    pooya::MulDiv _muldiv2{this, "*///"};
-    pooya::Subtract _sub{this};
+    pooya::Integrator _integ1{this, "dphi", M_PI_4};
+    pooya::Integrator _integ2{this, "phi"};
+    // pooya::SISOFunction _sin{this, "sin(phi)", [](double /*t*/, double x) -> double { return std::sin(x); }};
+    // pooya::SOFunction _sin{this, "sin(phi)", [](double /*t*/, const pooya::Bus& ibus) -> double
+    //                        { return std::sin(ibus.scalar_at(0)->get()); }};
+    // pooya::Function _sin{this, "sin(phi)", [](double /*t*/, const pooya::Bus& ibus, const pooya::Bus& obus) -> void
+    //                      { obus.scalar_at(0)->set(std::sin(ibus.scalar_at(0)->get())); }};
+    pooya::Sin _sin{this, "sin(phi)"};
+    pooya::MulDiv _muldiv1{this, "g_l", "**/"};
+    pooya::MulDiv _muldiv2{this, "tau_ml2", "*///"};
+    pooya::Subtract _sub{this, "d2phi"};
 
 public:
     pooya::ScalarSignal _tau{"tau"};
@@ -59,13 +59,6 @@ public:
     Pendulum()
     {
         pooya_trace0;
-
-        _integ1.rename("dphi");
-        _integ2.rename("phi");
-        _sin.rename("sin(phi)");
-        _muldiv1.rename("g_l");
-        _muldiv2.rename("tau_ml2");
-        _sub.rename("d2phi");
 
         pooya::ScalarSignal s10;
         pooya::ScalarSignal s20;

--- a/samples/test07_pendulum_with_pi.cpp
+++ b/samples/test07_pendulum_with_pi.cpp
@@ -16,6 +16,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 */
 
 #include <chrono>
+#include <cstddef>
 #include <iostream>
 
 #include "src/block/add.hpp"
@@ -34,19 +35,19 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 class Pendulum : public pooya::Submodel
 {
 protected:
-    pooya::MulDiv _muldiv1{this, "*///"};
+    pooya::MulDiv _muldiv1{this, "", "*///"};
     pooya::Subtract _sub{this};
     pooya::Integrator _integ1{this};
     pooya::Integrator _integ2{this};
     pooya::Sin _sin{this};
-    pooya::MulDiv _muldiv2{this, "**/"};
+    pooya::MulDiv _muldiv2{this, "", "**/"};
 
 public:
     pooya::ScalarSignal _m;
     pooya::ScalarSignal _g;
     pooya::ScalarSignal _l;
 
-    explicit Pendulum() { rename("pendulum"); }
+    explicit Pendulum() : pooya::Submodel(nullptr, "pendulum") {}
 
     bool connect(const pooya::Bus& ibus, const pooya::Bus& obus) override
     {
@@ -85,7 +86,10 @@ protected:
     pooya::Add _add{this};
 
 public:
-    PI(double Kp, double Ki, double x0 = 0.0) : _gain_p(this, Kp), _integ(this, x0), _gain_i(this, Ki) { rename("PI"); }
+    PI(double Kp, double Ki, double x0 = 0.0)
+        : pooya::Submodel(nullptr, "PI"), _gain_p(this, "Kp", Kp), _integ(this, "ix", x0), _gain_i(this, "Ki", Ki)
+    {
+    }
 
     bool connect(const pooya::Bus& ibus, const pooya::Bus& obus) override
     {

--- a/samples/test08_pendulum_with_pid.cpp
+++ b/samples/test08_pendulum_with_pid.cpp
@@ -35,24 +35,15 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 class Pendulum : public pooya::Submodel
 {
 protected:
-    pooya::MulDiv _muldiv1{this, "*///"};
-    pooya::Subtract _sub{this};
-    pooya::Integrator _integ1{this};
-    pooya::Integrator _integ2{this};
-    pooya::Sin _sin{this};
-    pooya::MulDiv _muldiv2{this, "**/"};
+    pooya::MulDiv _muldiv1{this, "tau_ml2", "*///"};
+    pooya::Subtract _sub{this, "err"};
+    pooya::Integrator _integ1{this, "dphi"};
+    pooya::Integrator _integ2{this, "phi"};
+    pooya::Sin _sin{this, "sin(phi)"};
+    pooya::MulDiv _muldiv2{this, "g_l", "**/"};
 
 public:
-    Pendulum(pooya::Submodel* parent) : pooya::Submodel(parent)
-    {
-        rename("pendulum");
-        _muldiv1.rename("tau_ml2");
-        _sub.rename("err");
-        _integ1.rename("dphi");
-        _integ2.rename("phi");
-        _sin.rename("sin(phi)");
-        _muldiv2.rename("g_l");
-    }
+    Pendulum(pooya::Submodel* parent) : pooya::Submodel(parent, "pendulum") {}
 
     pooya::ScalarSignal _m{"m"};
     pooya::ScalarSignal _g{"g"};
@@ -97,13 +88,9 @@ protected:
 
 public:
     PID(pooya::Submodel* parent, double Kp, double Ki, double Kd, double x0 = 0.0)
-        : pooya::Submodel(parent), _gain_p(this, Kp), _integ(this, x0), _gain_i(this, Ki), _gain_d(this, Kd)
+        : pooya::Submodel(parent, "PI"), _gain_p(this, "Kp", Kp), _integ(this, "ix", x0), _gain_i(this, "Ki", Ki),
+          _gain_d(this, "Kd", Kd)
     {
-        rename("PI");
-        _gain_p.rename("Kp");
-        _integ.rename("ix");
-        _gain_i.rename("Ki");
-        _gain_d.rename("Kd");
     }
 
     bool connect(const pooya::Bus& ibus, const pooya::Bus& obus) override
@@ -146,10 +133,8 @@ public:
     pooya::ScalarSignal _tau{"tau"};
     pooya::ScalarSignal _err{"err"};
 
-    PendulumWithPID()
+    PendulumWithPID() : pooya::Submodel(nullptr, "pendulum_with_PID")
     {
-        rename("pendulum_with_PID");
-
         _sub.connect({_des_phi, _phi}, _err);
         _pid.connect(_err, _tau);
         _pend.connect(_tau, _phi);

--- a/samples/test10_memory_with_bus.cpp
+++ b/samples/test10_memory_with_bus.cpp
@@ -59,8 +59,7 @@ int main()
     auto start  = std::chrono::high_resolution_clock::now();
 
     // create pooya blocks
-    pooya::Submodel model;
-    model.rename("test10");
+    pooya::Submodel model(nullptr, "test10");
     pooya::BusMemory bus_memory(model, {{"Z.z3", 1.0}}, {"x1"});
 
     // create buses (signals)

--- a/samples/tut01_mass_spring_damper.cpp
+++ b/samples/tut01_mass_spring_damper.cpp
@@ -32,13 +32,13 @@ int main()
 
     // create pooya blocks
     pooya::Submodel model;
-    pooya::Source src_F(&model, [](double t) -> double { return t < 1 ? 0 : 1; });
-    pooya::Gain gain_1_m(&model, 1 / m);
-    pooya::AddSub addsub_rhs(&model, "+--");
+    pooya::Source src_F(&model, "", [](double t) -> double { return t < 1 ? 0 : 1; });
+    pooya::Gain gain_1_m(&model, "", 1 / m);
+    pooya::AddSub addsub_rhs(&model, "", "+--");
     pooya::Integrator int_xdd(&model);
     pooya::Integrator int_xd(&model);
-    pooya::Gain gain_c_m(&model, c / m);
-    pooya::Gain gain_k_m(&model, k / m);
+    pooya::Gain gain_c_m(&model, "", c / m);
+    pooya::Gain gain_k_m(&model, "", k / m);
 
     // create pooya signals
     pooya::ScalarSignal s_F;

--- a/src/block/add.hpp
+++ b/src/block/add.hpp
@@ -33,7 +33,9 @@ class AddT : public AddSubT<T>
 {
 public:
     explicit AddT(const T& initial = 0.0) : AddSubT<T>("", initial) {}
-    AddT(Submodel* parent, const T& initial = 0.0) : AddSubT<T>(parent, "", initial) {}
+    AddT(Submodel* parent, std::string_view name = "", const T& initial = 0.0) : AddSubT<T>(parent, name, "", initial)
+    {
+    }
 
     bool connect(const Bus& ibus, const Bus& obus) override
     {

--- a/src/block/addsub.hpp
+++ b/src/block/addsub.hpp
@@ -41,8 +41,8 @@ public:
         : SingleOutputT<T>(Block::NoIOLimit, 1), _operators(operators), _initial(initial)
     {
     }
-    AddSubT(Submodel* parent, const std::string& operators, const T& initial = 0.0)
-        : SingleOutputT<T>(parent, Block::NoIOLimit, 1), _operators(operators), _initial(initial)
+    AddSubT(Submodel* parent, std::string_view name, const std::string& operators, const T& initial = 0.0)
+        : SingleOutputT<T>(parent, name, Block::NoIOLimit, 1), _operators(operators), _initial(initial)
     {
     }
 

--- a/src/block/block.cpp
+++ b/src/block/block.cpp
@@ -31,8 +31,8 @@ Block::Block(uint16_t num_iports, uint16_t num_oports) : _num_iports(num_iports)
     if (_parent) _parent->link_block(*this);
 }
 
-Block::Block(Submodel* parent, uint16_t num_iports, uint16_t num_oports)
-    : _parent(parent), _num_iports(num_iports), _num_oports(num_oports)
+Block::Block(Submodel* parent, std::string_view name, uint16_t num_iports, uint16_t num_oports)
+    : NamedObject(name), _parent(parent), _num_iports(num_iports), _num_oports(num_oports)
 {
     if (_parent) _parent->link_block(*this);
 }

--- a/src/block/block.hpp
+++ b/src/block/block.hpp
@@ -67,8 +67,9 @@ protected:
     bool _processed{false};
     bool link_signal(const ValueSignalImplPtr& sig, SignalLinkType type);
 
-    explicit Block(uint16_t num_iports = NoIOLimit, uint16_t num_oports = NoIOLimit);
-    Block(Submodel* parent, uint16_t num_iports = NoIOLimit, uint16_t num_oports = NoIOLimit);
+    Block(uint16_t num_iports = NoIOLimit, uint16_t num_oports = NoIOLimit);
+    Block(Submodel* parent, std::string_view name = "", uint16_t num_iports = NoIOLimit,
+          uint16_t num_oports = NoIOLimit);
 
 public:
     virtual ~Block() = default;

--- a/src/block/bus_block_builder.hpp
+++ b/src/block/bus_block_builder.hpp
@@ -44,7 +44,7 @@ protected:
                                const SignalImplPtr& sig_out) = 0;
 
 public:
-    explicit BusBlockBuilder(Submodel& parent, const std::initializer_list<std::string>& excluded_labels = {})
+    BusBlockBuilder(Submodel& parent, const std::initializer_list<std::string>& excluded_labels = {})
         : Leaf(&parent), _excluded_labels(excluded_labels)
     {
     }

--- a/src/block/bus_memory.cpp
+++ b/src/block/bus_memory.cpp
@@ -52,22 +52,23 @@ void BusMemory::block_builder(const std::string& full_label, const SignalImplPtr
     if (sig_in->is_scalar())
     {
         block = (it == _init_values.end()) ? std::make_shared<Memory>(_parent)
-                                           : std::make_shared<Memory>(_parent, it->second.as_scalar());
+                                           : std::make_shared<Memory>(_parent, "", it->second.as_scalar());
     }
     else if (sig_in->is_int())
     {
         block = (it == _init_values.end()) ? std::make_shared<MemoryI>(_parent)
-                                           : std::make_shared<MemoryI>(_parent, std::round(it->second.as_scalar()));
+                                           : std::make_shared<MemoryI>(_parent, "", std::round(it->second.as_scalar()));
     }
     else if (sig_in->is_bool())
     {
         block = (it == _init_values.end()) ? std::make_shared<MemoryB>(_parent)
-                                           : std::make_shared<MemoryB>(_parent, Bool(it->second.as_scalar() != 0));
+                                           : std::make_shared<MemoryB>(_parent, "", Bool(it->second.as_scalar() != 0));
     }
     else if (sig_in->is_array())
     {
-        block = (it == _init_values.end()) ? std::make_shared<MemoryA>(_parent, Array::Zero(sig_in->as_array().size()))
-                                           : std::make_shared<MemoryA>(_parent, it->second.as_array());
+        block = (it == _init_values.end())
+                    ? std::make_shared<MemoryA>(_parent, "", Array::Zero(sig_in->as_array().size()))
+                    : std::make_shared<MemoryA>(_parent, "", it->second.as_array());
     }
     else
     {

--- a/src/block/bus_pipe.hpp
+++ b/src/block/bus_pipe.hpp
@@ -30,7 +30,7 @@ namespace pooya
 class BusPipe : public BusBlockBuilder
 {
 public:
-    explicit BusPipe(Submodel& parent, const std::initializer_list<std::string>& excluded_labels = {})
+    BusPipe(Submodel& parent, const std::initializer_list<std::string>& excluded_labels = {})
         : BusBlockBuilder(parent, excluded_labels)
     {
     }

--- a/src/block/const.hpp
+++ b/src/block/const.hpp
@@ -36,7 +36,9 @@ protected:
 
 public:
     explicit ConstT(const T& value) : SingleOutputT<T>(0), _value(value) {}
-    ConstT(Submodel* parent, const T& value) : SingleOutputT<T>(parent, 0), _value(value) {}
+    ConstT(Submodel* parent, std::string_view name, const T& value) : SingleOutputT<T>(parent, name, 0), _value(value)
+    {
+    }
 
     void activation_function(double /*t*/) override
     {

--- a/src/block/delay.hpp
+++ b/src/block/delay.hpp
@@ -44,7 +44,10 @@ protected:
 
 public:
     explicit DelayT(double lifespan) : SingleOutputT<T>(3, 1), _lifespan(lifespan) {}
-    DelayT(Submodel* parent, double lifespan) : SingleOutputT<T>(parent, 3, 1), _lifespan(lifespan) {}
+    DelayT(Submodel* parent, std::string_view name, double lifespan)
+        : SingleOutputT<T>(parent, name, 3, 1), _lifespan(lifespan)
+    {
+    }
 
     bool connect(const Bus& ibus, const Bus& obus) override
     {

--- a/src/block/derivative.hpp
+++ b/src/block/derivative.hpp
@@ -39,7 +39,10 @@ protected:
 
 public:
     explicit DerivativeT(const T& y0 = 0) : SingleInputOutputT<T>(1), _y(y0) {}
-    DerivativeT(Submodel* parent, const T& y0 = 0) : SingleInputOutputT<T>(parent, 1), _y(y0) {}
+    DerivativeT(Submodel* parent, std::string_view name = "", const T& y0 = 0)
+        : SingleInputOutputT<T>(parent, name, 1), _y(y0)
+    {
+    }
 
     void post_step(double t) override
     {

--- a/src/block/divide.hpp
+++ b/src/block/divide.hpp
@@ -33,7 +33,10 @@ class DivideT : public MulDivT<T>
 {
 public:
     explicit DivideT(const T& initial = 1.0) : MulDivT<T>("*/", initial) {}
-    DivideT(Submodel* parent, const T& initial = 1.0) : MulDivT<T>(parent, "*/", initial) {}
+    DivideT(Submodel* parent, std::string_view name = "", const T& initial = 1.0)
+        : MulDivT<T>(parent, name, "*/", initial)
+    {
+    }
 };
 
 using Divide  = DivideT<double>;

--- a/src/block/function.hpp
+++ b/src/block/function.hpp
@@ -38,12 +38,13 @@ protected:
     ActFunction _act_func;
 
 public:
-    Function(Submodel* parent, ActFunction act_func, uint16_t num_iports = NoIOLimit, uint16_t num_oports = NoIOLimit)
-        : Leaf(parent, num_iports, num_oports), _act_func(act_func)
+    Function(ActFunction act_func, uint16_t num_iports = NoIOLimit, uint16_t num_oports = NoIOLimit)
+        : Leaf(num_iports, num_oports), _act_func(act_func)
     {
     }
-    Function(Submodel* parent, ActFunction act_func, uint16_t num_iports = NoIOLimit, uint16_t num_oports = NoIOLimit)
-        : Leaf(parent, num_iports, num_oports), _act_func(act_func)
+    Function(Submodel* parent, std::string_view name, ActFunction act_func, uint16_t num_iports = NoIOLimit,
+             uint16_t num_oports = NoIOLimit)
+        : Leaf(parent, name, num_iports, num_oports), _act_func(act_func)
     {
     }
 

--- a/src/block/gain.hpp
+++ b/src/block/gain.hpp
@@ -36,7 +36,7 @@ protected:
 
 public:
     GainT(GainType k) : SingleInputOutputT<T>(1), _k(k) {}
-    GainT(Submodel* parent, GainType k) : SingleInputOutputT<T>(parent, 1), _k(k) {}
+    GainT(Submodel* parent, std::string_view name, GainType k) : SingleInputOutputT<T>(parent, name, 1), _k(k) {}
 
     void activation_function(double /*t*/) override
     {

--- a/src/block/initial_value.hpp
+++ b/src/block/initial_value.hpp
@@ -36,7 +36,7 @@ protected:
     bool _init{true};
 
 public:
-    explicit InitialValueT(const ValidName& name = "") : SingleInputOutputT<T>(name, 1) {}
+    InitialValueT(Submodel* parent = nullptr, std::string_view name = "") : SingleInputOutputT<T>(parent, name, 1) {}
 
     void activation_function(double /*t*/) override
     {

--- a/src/block/integrator.hpp
+++ b/src/block/integrator.hpp
@@ -33,7 +33,10 @@ class IntegratorT : public IntegratorBaseT<T>
 {
 public:
     explicit IntegratorT(T ic = T(0.0)) : IntegratorBaseT<T>(ic, 1, 1) {}
-    IntegratorT(Submodel* parent, T ic = T(0.0)) : IntegratorBaseT<T>(parent, ic, 1, 1) {}
+    IntegratorT(Submodel* parent, std::string_view name = "", T ic = T(0.0))
+        : IntegratorBaseT<T>(parent, name, ic, 1, 1)
+    {
+    }
 };
 
 using Integrator  = IntegratorT<double>;

--- a/src/block/integrator_base.hpp
+++ b/src/block/integrator_base.hpp
@@ -34,14 +34,13 @@ protected:
     T _value;
 
 public:
-    explicit IntegratorBaseT(T ic = T(0.0), uint16_t num_iports = Block::NoIOLimit,
-                             uint16_t num_oports = Block::NoIOLimit)
+    IntegratorBaseT(T ic = T(0.0), uint16_t num_iports = Block::NoIOLimit, uint16_t num_oports = Block::NoIOLimit)
         : SingleOutputT<T>(num_iports, num_oports), _value(ic)
     {
     }
-    IntegratorBaseT(Submodel* parent, T ic = T(0.0), uint16_t num_iports = Block::NoIOLimit,
+    IntegratorBaseT(Submodel* parent, std::string_view name = "", T ic = T(0.0), uint16_t num_iports = Block::NoIOLimit,
                     uint16_t num_oports = Block::NoIOLimit)
-        : SingleOutputT<T>(parent, num_iports, num_oports), _value(ic)
+        : SingleOutputT<T>(parent, name, num_iports, num_oports), _value(ic)
     {
     }
 

--- a/src/block/leaf.hpp
+++ b/src/block/leaf.hpp
@@ -26,9 +26,9 @@ namespace pooya
 class Leaf : public Block
 {
 protected:
-    explicit Leaf(uint16_t num_iports = NoIOLimit, uint16_t num_oports = NoIOLimit) : Block(num_iports, num_oports) {}
-    Leaf(Submodel* parent, uint16_t num_iports = NoIOLimit, uint16_t num_oports = NoIOLimit)
-        : Block(parent, num_iports, num_oports)
+    Leaf(uint16_t num_iports = NoIOLimit, uint16_t num_oports = NoIOLimit) : Block(num_iports, num_oports) {}
+    Leaf(Submodel* parent, std::string_view name = "", uint16_t num_iports = NoIOLimit, uint16_t num_oports = NoIOLimit)
+        : Block(parent, name, num_iports, num_oports)
     {
     }
 

--- a/src/block/memory.hpp
+++ b/src/block/memory.hpp
@@ -36,7 +36,10 @@ protected:
 
 public:
     explicit MemoryT(const Tic& ic = Tic(0)) : SingleInputOutputT<T>(1), _value(ic) {}
-    MemoryT(Submodel* parent, const Tic& ic = Tic(0)) : SingleInputOutputT<T>(parent, 1), _value(ic) {}
+    MemoryT(Submodel* parent, std::string_view name = "", const Tic& ic = Tic(0))
+        : SingleInputOutputT<T>(parent, name, 1), _value(ic)
+    {
+    }
 
     void post_step(double /*t*/) override
     {

--- a/src/block/muldiv.hpp
+++ b/src/block/muldiv.hpp
@@ -41,8 +41,8 @@ public:
         : SingleOutputT<T>(Block::NoIOLimit, 1), _operators(operators), _initial(initial)
     {
     }
-    MulDivT(Submodel* parent, const std::string& operators, const T& initial = 1.0)
-        : SingleOutputT<T>(parent, Block::NoIOLimit, 1), _operators(operators), _initial(initial)
+    MulDivT(Submodel* parent, std::string_view name, const std::string& operators, const T& initial = 1.0)
+        : SingleOutputT<T>(parent, name, Block::NoIOLimit, 1), _operators(operators), _initial(initial)
     {
     }
 

--- a/src/block/multiply.hpp
+++ b/src/block/multiply.hpp
@@ -33,7 +33,10 @@ class MultiplyT : public MulDivT<T>
 {
 public:
     explicit MultiplyT(const T& initial = 1.0) : MulDivT<T>(initial) {}
-    MultiplyT(Submodel* parent, const T& initial = 1.0) : MulDivT<T>(parent, "", initial) {}
+    MultiplyT(Submodel* parent, std::string_view name = "", const T& initial = 1.0)
+        : MulDivT<T>(parent, name, "", initial)
+    {
+    }
 
     bool connect(const Bus& ibus, const Bus& obus) override
     {

--- a/src/block/pipe.hpp
+++ b/src/block/pipe.hpp
@@ -32,8 +32,7 @@ template<typename T>
 class PipeT : public SingleInputOutputT<T>
 {
 public:
-    PipeT() : SingleInputOutputT<T>(1) {}
-    PipeT(Submodel* parent) : SingleInputOutputT<T>(parent, 1) {}
+    PipeT(Submodel* parent = nullptr, std::string_view name = "") : SingleInputOutputT<T>(parent, name, 1) {}
 
     void activation_function(double /*t*/) override
     {

--- a/src/block/sin.hpp
+++ b/src/block/sin.hpp
@@ -32,7 +32,7 @@ template<typename T>
 class SinT : public SingleInputOutputT<T>
 {
 public:
-    explicit SinT(Submodel* parent = nullptr) : SingleInputOutputT<T>(parent, 1) {}
+    SinT(Submodel* parent = nullptr, std::string_view name = "") : SingleInputOutputT<T>(parent, name, 1) {}
 
     void activation_function(double /*t*/) override
     {

--- a/src/block/singlei.hpp
+++ b/src/block/singlei.hpp
@@ -23,19 +23,23 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 namespace pooya
 {
 
-template<typename T>
-class SingleInputT : public Leaf
+template<typename T, typename Base = Leaf>
+class SingleInputT : public Base
 {
 protected:
     typename Types<T>::Signal _s_in;
 
-    explicit SingleInputT(uint16_t num_oports = NoIOLimit) : Leaf(1, num_oports) {}
-    SingleInputT(Submodel* parent, uint16_t num_oports = NoIOLimit) : Leaf(parent, 1, num_oports) {}
-    SingleInputT(uint16_t num_iports, uint16_t num_oports) : Leaf(num_iports, num_oports)
+    explicit SingleInputT(uint16_t num_oports = Block::NoIOLimit) : Base(1, num_oports) {}
+    SingleInputT(Submodel* parent, std::string_view name = "", uint16_t num_oports = Block::NoIOLimit)
+        : Base(parent, name, 1, num_oports)
+    {
+    }
+    SingleInputT(uint16_t num_iports, uint16_t num_oports) : Base(num_iports, num_oports)
     {
         pooya_verify(num_iports == 1, "One and only one input expected!");
     }
-    SingleInputT(Submodel* parent, uint16_t num_iports, uint16_t num_oports) : Leaf(parent, num_iports, num_oports)
+    SingleInputT(Submodel* parent, std::string_view name, uint16_t num_iports, uint16_t num_oports)
+        : Base(parent, name, num_iports, num_oports)
     {
         pooya_verify(num_iports == 1, "One and only one input expected!");
     }
@@ -43,11 +47,11 @@ protected:
 public:
     bool connect(const Bus& ibus, const Bus& obus) override
     {
-        if (!Leaf::connect(ibus, obus))
+        if (!Base::connect(ibus, obus))
         {
             return false;
         }
-        _s_in.reset(Types<T>::as_signal_id(_ibus.at(0)));
+        _s_in.reset(Types<T>::as_signal_id(Base::_ibus.at(0)));
         return true;
     }
 };

--- a/src/block/singleo.hpp
+++ b/src/block/singleo.hpp
@@ -29,13 +29,13 @@ class SingleOutputT : public Base
 protected:
     typename Types<T>::Signal _s_out;
 
-    explicit SingleOutputT(uint16_t num_iports = Block::NoIOLimit, uint16_t num_oports = 1)
-        : Base(num_iports, num_oports)
+    SingleOutputT(uint16_t num_iports = Block::NoIOLimit, uint16_t num_oports = 1) : Base(num_iports, num_oports)
     {
         pooya_verify(num_oports == 1, "One and only one output expected!");
     }
-    SingleOutputT(Submodel* parent, uint16_t num_iports = Block::NoIOLimit, uint16_t num_oports = 1)
-        : Base(parent, num_iports, num_oports)
+    SingleOutputT(Submodel* parent, std::string_view name = "", uint16_t num_iports = Block::NoIOLimit,
+                  uint16_t num_oports = 1)
+        : Base(parent, name, num_iports, num_oports)
     {
         pooya_verify(num_oports == 1, "One and only one output expected!");
     }

--- a/src/block/siso_function.hpp
+++ b/src/block/siso_function.hpp
@@ -38,11 +38,11 @@ protected:
     ActFunction _act_func;
 
 public:
-    explicit SISOFunctionT(Submodel* parent, ActFunction act_func)
-        : SingleInputOutputT<T>(parent, 1), _act_func(act_func)
+    explicit SISOFunctionT(ActFunction act_func) : SingleInputOutputT<T>(1), _act_func(act_func) {}
+    SISOFunctionT(Submodel* parent, std::string_view name, ActFunction act_func)
+        : SingleInputOutputT<T>(parent, name, 1), _act_func(act_func)
     {
     }
-    SISOFunctionT(Submodel* parent, ActFunction act_func) : SingleInputOutputT<T>(parent, 1), _act_func(act_func) {}
 
     void activation_function(double t) override
     {

--- a/src/block/so_function.hpp
+++ b/src/block/so_function.hpp
@@ -38,12 +38,12 @@ protected:
     ActFunction _act_func;
 
 public:
-    SOFunctionT(Submodel* parent, ActFunction act_func, uint16_t num_iports = Block::NoIOLimit)
-        : SingleOutputT<T>(parent, num_iports), _act_func(act_func)
+    SOFunctionT(ActFunction act_func, uint16_t num_iports = Block::NoIOLimit)
+        : SingleOutputT<T>(num_iports), _act_func(act_func)
     {
     }
-    SOFunctionT(Submodel* parent, ActFunction act_func, uint16_t num_iports = Block::NoIOLimit)
-        : SingleOutputT<T>(parent, num_iports), _act_func(act_func)
+    SOFunctionT(Submodel* parent, std::string_view name, ActFunction act_func, uint16_t num_iports = Block::NoIOLimit)
+        : SingleOutputT<T>(parent, name, num_iports), _act_func(act_func)
     {
     }
 

--- a/src/block/source.hpp
+++ b/src/block/source.hpp
@@ -22,7 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef __POOYA_BLOCK_SOURCE_HPP__
 #define __POOYA_BLOCK_SOURCE_HPP__
 
-#include "singleio.hpp"
+#include "singleo.hpp"
 #include "src/signal/array.hpp"
 
 namespace pooya
@@ -39,7 +39,10 @@ protected:
 
 public:
     explicit SourceT(SourceFunction src_func) : _src_func(src_func) {}
-    SourceT(Submodel* parent, SourceFunction src_func) : SingleOutputT<T>(parent), _src_func(src_func) {}
+    SourceT(Submodel* parent, std::string_view name, SourceFunction src_func)
+        : SingleOutputT<T>(parent, name), _src_func(src_func)
+    {
+    }
 
     void activation_function(double t) override
     {

--- a/src/block/sources.hpp
+++ b/src/block/sources.hpp
@@ -37,8 +37,8 @@ protected:
 
 public:
     Sources(SourcesFunction src_func, uint16_t num_oports = NoIOLimit) : Leaf(0, num_oports), _src_func(src_func) {}
-    Sources(const ValidName& name, SourcesFunction src_func, uint16_t num_oports = NoIOLimit)
-        : Leaf(name, 0, num_oports), _src_func(src_func)
+    Sources(Submodel* parent, std::string_view name, SourcesFunction src_func, uint16_t num_oports = NoIOLimit)
+        : Leaf(parent, name, 0, num_oports), _src_func(src_func)
     {
     }
 

--- a/src/block/submodel.hpp
+++ b/src/block/submodel.hpp
@@ -29,11 +29,10 @@ protected:
     std::vector<Block*> _blocks;
 
 public:
-    explicit Submodel(uint16_t num_iports = NoIOLimit, uint16_t num_oports = NoIOLimit) : Block(num_iports, num_oports)
-    {
-    }
-    Submodel(Submodel* parent, uint16_t num_iports = NoIOLimit, uint16_t num_oports = NoIOLimit)
-        : Block(parent, num_iports, num_oports)
+    Submodel(uint16_t num_iports = NoIOLimit, uint16_t num_oports = NoIOLimit) : Block(num_iports, num_oports) {}
+    Submodel(Submodel* parent, std::string_view name = "", uint16_t num_iports = NoIOLimit,
+             uint16_t num_oports = NoIOLimit)
+        : Block(parent, name, num_iports, num_oports)
     {
     }
 

--- a/src/block/subtract.hpp
+++ b/src/block/subtract.hpp
@@ -33,7 +33,10 @@ class SubtractT : public AddSubT<T>
 {
 public:
     explicit SubtractT(const T& initial = 0.0) : AddSubT<T>("+-", initial) {}
-    SubtractT(Submodel* parent, const T& initial = 0.0) : AddSubT<T>(parent, "+-", initial) {}
+    SubtractT(Submodel* parent, std::string_view name = "", const T& initial = 0.0)
+        : AddSubT<T>(parent, name, "+-", initial)
+    {
+    }
 };
 
 using Subtract  = SubtractT<double>;

--- a/src/block/triggered_integrator.hpp
+++ b/src/block/triggered_integrator.hpp
@@ -37,7 +37,10 @@ protected:
 
 public:
     explicit TriggeredIntegratorT(T ic = T(0.0)) : IntegratorBaseT<T>(ic, 2, 1) {}
-    TriggeredIntegratorT(Submodel* parent, T ic = T(0.0)) : IntegratorBaseT<T>(parent, ic, 2, 1) {}
+    TriggeredIntegratorT(Submodel* parent, std::string_view name, T ic = T(0.0))
+        : IntegratorBaseT<T>(parent, name, ic, 2, 1)
+    {
+    }
 
     bool connect(const Bus& ibus, const Bus& obus) override
     {

--- a/src/shared/named_object.cpp
+++ b/src/shared/named_object.cpp
@@ -22,7 +22,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 namespace pooya
 {
 
-std::string ValidName::emend(const std::string& name)
+std::string ValidName::emend(std::string_view name)
 {
     std::string ret(name);
     std::for_each(

--- a/src/shared/named_object.hpp
+++ b/src/shared/named_object.hpp
@@ -19,6 +19,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 #define __POOYA_NAMED_OBJECT_HPP__
 
 #include <string>
+#include <string_view>
 
 namespace pooya
 {
@@ -40,6 +41,7 @@ public:
     ValidName()                 = default;
     ValidName(const ValidName&) = default;
     ValidName(const char* name) : _name(emend(std::string(name))) {}
+    ValidName(std::string_view name) : _name(emend(name)) {}
     ValidName(const std::string& name) : _name(emend(name)) {}
 
     ValidName& operator=(const ValidName&) = default;
@@ -66,7 +68,8 @@ public:
         return append(name, "/");
     }
 
-    static std::string emend(const std::string& name);
+    static std::string emend(std::string_view name);
+    static std::string emend(const std::string& name) { return emend(std::string_view(name)); }
     static std::string emend(const ValidName& name) { return name._name; }
 };
 


### PR DESCRIPTION
This PR adds block names to constructors. Being able to set the block name while constructing improves debugging.